### PR TITLE
test: break validation test to demonstrate CI/CD failure detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,23 @@
 name: Run Tests
-on: [push, pull_request]
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:  # Allows manual trigger from GitHub UI
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.12'
+
     - name: Install dependencies
       run: pip install -r requirements.txt
+
     - name: Run tests
       run: pytest main.py -v

--- a/main.py
+++ b/main.py
@@ -51,7 +51,8 @@ def test_valid_campaign_passes(clean_campaign, required_fields):
     Why: Positive test - confirms valid data is accepted
     Fixtures: clean_campaign, required_fields
     """
-    assert validate_campaign_data(clean_campaign, required_fields) is True
+    # TODO: Fix this test - intentionally failing for CI/CD demo
+    assert validate_campaign_data(clean_campaign, required_fields) is False  # Should be True!
 
 def test_invalid_dates_fail(campaign_bad_dates):
     """


### PR DESCRIPTION
- Intentionally change assertion in test_valid_campaign_passes (True -> False)
- Add workflow_dispatch trigger for manual test runs
- Update setup-python action to v4

This commit demonstrates how CI catches bugs before merge.