### PR TITLE
test: break validation test to demonstrate CI/CD failure detection

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,7 +51,8 @@ def test_valid_campaign_passes(clean_campaign, required_fields):
     Why: Positive test - confirms valid data is accepted
     Fixtures: clean_campaign, required_fields
     """
-    assert validate_campaign_data(clean_campaign, required_fields) is True
+    # TODO: Fix this test - intentionally failing for CI/CD demo
+    assert validate_campaign_data(clean_campaign, required_fields) is False  # Should be True!
 
 def test_invalid_dates_fail(campaign_bad_dates):
     """


### PR DESCRIPTION
Intentionally change assertion in test_valid_campaign_passes from True to False. This will cause pytest to fail, demonstrating how CI catches bugs before merge.

To fix: change line 55 back to 'is True'